### PR TITLE
Implement article relevance filtering in translation pipeline

### DIFF
--- a/src/main/java/com/huawei/ai_platform/rss/application/repo/RssArticleTranslatorRepository.java
+++ b/src/main/java/com/huawei/ai_platform/rss/application/repo/RssArticleTranslatorRepository.java
@@ -1,6 +1,5 @@
 package com.huawei.ai_platform.rss.application.repo;
 
-import com.huawei.ai_platform.common.OperationResult;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.translation.AiTranslationResponse;
 import com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum;
 import com.huawei.ai_platform.rss.model.RssData;
@@ -38,6 +37,15 @@ public interface RssArticleTranslatorRepository {
      * @param statusEnum which status do you want
      */
     void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum);
+
+    /**
+     * Updates data by list of the statuses with reason
+     *
+     * @param idList     list of id data
+     * @param statusEnum which status do you want
+     * @param reason     reason for the update
+     */
+    void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum, String reason);
 
     /**
      * Creates new article translation

--- a/src/main/java/com/huawei/ai_platform/rss/application/service/RssTranslationOrchestration.java
+++ b/src/main/java/com/huawei/ai_platform/rss/application/service/RssTranslationOrchestration.java
@@ -28,6 +28,13 @@ public interface RssTranslationOrchestration {
     void cleanInputText(AiCleaningRequest cleaningRequests);
 
     /**
+     * Performs relevance check
+     *
+     * @param cleaningRequests clean request for the article
+     */
+    void checkRelevance(AiCleaningRequest cleaningRequests);
+
+    /**
      * Translated input data
      *
      * @param aiTranslationRequestList ai translation request

--- a/src/main/java/com/huawei/ai_platform/rss/application/service/RssTranslationService.java
+++ b/src/main/java/com/huawei/ai_platform/rss/application/service/RssTranslationService.java
@@ -40,6 +40,15 @@ public interface RssTranslationService {
     void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum);
 
     /**
+     * Updates status for group of the records with reason
+     *
+     * @param idList     list of ID articles
+     * @param statusEnum which status do you want to set
+     * @param reason     reason for the update
+     */
+    void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum, String reason);
+
+    /**
      * Performs inserting translations
      *
      * @param rssDataList list of the rss data

--- a/src/main/java/com/huawei/ai_platform/rss/application/service/impl/RssServiceImpl.java
+++ b/src/main/java/com/huawei/ai_platform/rss/application/service/impl/RssServiceImpl.java
@@ -27,12 +27,10 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum.FAILURE;
 import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum.INIT;
@@ -160,8 +158,8 @@ public class RssServiceImpl implements RssSyncService, RssConfigService, RssTran
                                 return rssTranslationOrchestration.initTranslation(item);
                             } else {
                                 if (item.getTranslationStatusEnum() == INIT || item.getTranslationStatusEnum() == FAILURE) {
-                                    AiCleaningRequest cleaningRequest = aiTranslationMapper.convert(item);
-                                    rssTranslationOrchestration.cleanInputText(cleaningRequest);
+                                    AiCleaningRequest relevanceRequest = aiTranslationMapper.convert(item);
+                                    rssTranslationOrchestration.checkRelevance(relevanceRequest);
 
                                     return OperationResult.builder().reason("Success").state(OperationResultEnum.SUCCESS).build();
                                 }
@@ -201,6 +199,15 @@ public class RssServiceImpl implements RssSyncService, RssConfigService, RssTran
         }
 
         rssArticleTranslatorRepository.queryUpdateStatusByListData(idList, statusEnum);
+    }
+
+    @Override
+    public void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum, String reason) {
+        if (CollectionUtils.isEmpty(idList) || statusEnum == null) {
+            throw new IllegalArgumentException("Arguments must be not null");
+        }
+
+        rssArticleTranslatorRepository.queryUpdateStatusByListData(idList, statusEnum, reason);
     }
 
     @Override

--- a/src/main/java/com/huawei/ai_platform/rss/application/service/impl/RssTranslationOrchestrationImpl.java
+++ b/src/main/java/com/huawei/ai_platform/rss/application/service/impl/RssTranslationOrchestrationImpl.java
@@ -5,13 +5,17 @@ import com.huawei.ai_platform.common.OperationResultEnum;
 import com.huawei.ai_platform.rss.application.service.RssTranslationOrchestration;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.AiCleaningRequest;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.AiCleaningResponse;
+import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.RelevanceCheckRequest;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.CleaningCreatedEvent;
+import com.huawei.ai_platform.rss.infrastructure.ai.model.event.RelevanceCheckCompletedEvent;
+import com.huawei.ai_platform.rss.infrastructure.ai.model.event.RelevanceCheckCreatedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationCompletedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationCreatedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationProcessingEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.translation.AiTranslationRequest;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.translation.AiTranslationResponse;
 import com.huawei.ai_platform.rss.infrastructure.ai.repo.AiCleaningArticlesRepo;
+import com.huawei.ai_platform.rss.infrastructure.ai.repo.AiRelevanceCheckRepo;
 import com.huawei.ai_platform.rss.infrastructure.ai.repo.AiTranslatorRepo;
 import com.huawei.ai_platform.rss.model.RssData;
 import lombok.RequiredArgsConstructor;
@@ -33,19 +37,37 @@ import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.Articl
 public class RssTranslationOrchestrationImpl implements RssTranslationOrchestration {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final AiCleaningArticlesRepo aiCleaningArticlesRepo;
+    private final AiRelevanceCheckRepo aiRelevanceCheckRepo;
     private final AiTranslatorRepo aiTranslatorRepo;
 
     @Override
     public OperationResult initTranslation(RssData inputList) {
-        log.info("STAGE 1 vs 3: accepting an ID = {}", inputList.getArticleId());
+        log.info("STAGE 1 vs 4: accepting an ID = {}", inputList.getArticleId());
         applicationEventPublisher.publishEvent(new TranslationCreatedEvent(inputList, INIT));
 
         return OperationResult.builder().state(OperationResultEnum.SUCCESS).reason("").build();
     }
 
     @Override
+    public void checkRelevance(AiCleaningRequest cleaningRequests) {
+        log.info("STAGE 2 vs 4: running relevance check for ID = {}", cleaningRequests.getId());
+
+        RelevanceCheckRequest request = RelevanceCheckRequest.builder()
+                .id(cleaningRequests.getId())
+                .title(cleaningRequests.getArticleTitle())
+                .content(cleaningRequests.getArticleContent())
+                .categoryName(cleaningRequests.getCategoryName())
+                .build();
+
+        AiRelevanceCheckRepo.RelevanceCheckResult result = aiRelevanceCheckRepo.checkRelevance(request);
+
+        applicationEventPublisher.publishEvent(new RelevanceCheckCompletedEvent(cleaningRequests, result.passed(), result.reason()));
+        log.info("STAGE 2 vs 4: relevance check completed with passed={}, score={} for ID = {}", result.passed(), result.score(), cleaningRequests.getId());
+    }
+
+    @Override
     public void cleanInputText(AiCleaningRequest cleaningRequests) {
-        log.info("STAGE 2 vs 3: running cleaning for the ID = {}", cleaningRequests.getId());
+        log.info("STAGE 3 vs 4: running cleaning for the ID = {}", cleaningRequests.getId());
         applicationEventPublisher.publishEvent(new CleaningCreatedEvent(cleaningRequests));
 
         AiCleaningResponse response = aiCleaningArticlesRepo.processCleaning(cleaningRequests);
@@ -57,25 +79,25 @@ public class RssTranslationOrchestrationImpl implements RssTranslationOrchestrat
             applicationEventPublisher.publishEvent(new TranslationProcessingEvent(aiTranslationRequest));
         } else {
             AiTranslationResponse translationResponse = AiTranslationResponse.failureResponse(response.getId(), response.getReason());
-            applicationEventPublisher.publishEvent(new TranslationCompletedEvent(translationResponse, FAILURE, "Some reason"));
+            applicationEventPublisher.publishEvent(new TranslationCompletedEvent(translationResponse, FAILURE, response.getReason()));
 
-            log.error("STAGE 2 vs 3: Translation for ID = {} has completed with failure :(", cleaningRequests.getId());
+            log.info("STAGE 3 vs 4: FAILURE for ID = {}", cleaningRequests.getId());
         }
     }
 
     @Override
     public void translateInputData(AiTranslationRequest aiTranslationRequestList) {
-        log.info("STAGE 3 vs 3: running translating for the ID = {}", aiTranslationRequestList.getArticleId());
+        log.info("STAGE 4 vs 4: running translating for the ID = {}", aiTranslationRequestList.getArticleId());
 
         AiTranslationResponse response = aiTranslatorRepo.translate(aiTranslationRequestList);
         if (response.isSuccess()) {
             applicationEventPublisher.publishEvent(new TranslationCompletedEvent(response, FINISH, "Success"));
-            log.info("STAGE 3 vs 3: translation for ID = {} has completed successfully", aiTranslationRequestList.getArticleId());
+            log.info("STAGE 4 vs 4: translation for ID = {} has completed successfully", aiTranslationRequestList.getArticleId());
         } else {
             AiTranslationResponse translationResponse = AiTranslationResponse.failureResponse(response.getArticleId(), response.getReason());
             applicationEventPublisher.publishEvent(new TranslationCompletedEvent(translationResponse, FAILURE, "Some reason"));
 
-            log.error("STAGE 3 vs 3: translation for ID = {} has completed with failure :(", aiTranslationRequestList.getArticleId());
+            log.error("STAGE 4 vs 4: translation for ID = {} has completed with failure :(", aiTranslationRequestList.getArticleId());
         }
     }
 }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/RssFacade.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/RssFacade.java
@@ -146,6 +146,11 @@ public class RssFacade implements RssRepository, RssArticleTranslatorRepository 
     }
 
     @Override
+    public void queryUpdateStatusByListData(List<Long> idList, ArticleTranslationStatusEnum statusEnum, String reason) {
+        persistenceRepo.queryUpdateStatusByListData(idList, statusEnum, reason);
+    }
+
+    @Override
     public void insertNewArticleTranslations(List<RssData> rssDataList, ArticleTranslationStatusEnum statusEnum) {
         persistenceRepo.insertArticleTranslations(rssDataList, INIT);
     }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/assembler/AiTranslationMapper.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/assembler/AiTranslationMapper.java
@@ -22,5 +22,6 @@ public abstract class AiTranslationMapper {
      */
     @Mapping(target = "articleTitle", source = "articleTitleEn")
     @Mapping(target = "id", source = "articleId")
+    @Mapping(target = "categoryName", source = "rssCategory.categoryNameEn")
     public abstract AiCleaningRequest convert(@Nonnull RssData rssData);
 }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/dto/ArticleSummary.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/dto/ArticleSummary.java
@@ -3,7 +3,6 @@ package com.huawei.ai_platform.rss.infrastructure.ai.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record ArticleSummary(
-    @JsonProperty("articleAbstract") String articleAbstract,
     @JsonProperty("background") String background,
     @JsonProperty("eventSummary") String eventSummary,
     @JsonProperty("technologyAndInnovation") String technologyAndInnovation,

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/event/AiEvents.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/event/AiEvents.java
@@ -1,22 +1,24 @@
 package com.huawei.ai_platform.rss.infrastructure.ai.event;
 
-import com.huawei.ai_platform.rss.application.service.RssTranslationOrchestration;
 import com.huawei.ai_platform.rss.application.service.RssTranslationService;
+import com.huawei.ai_platform.rss.application.service.RssTranslationOrchestration;
 import com.huawei.ai_platform.rss.infrastructure.ai.assembler.AiTranslationMapper;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.AiCleaningRequest;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.CleaningCreatedEvent;
+import com.huawei.ai_platform.rss.infrastructure.ai.model.event.RelevanceCheckCompletedEvent;
+import com.huawei.ai_platform.rss.infrastructure.ai.model.event.RelevanceCheckCreatedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationCompletedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationCreatedEvent;
 import com.huawei.ai_platform.rss.infrastructure.ai.model.event.TranslationProcessingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum.CLEANING_PROCESSING;
-import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum.TRANSLATING_PROCESSING;
+import static com.huawei.ai_platform.rss.infrastructure.persistence.enums.ArticleTranslationStatusEnum.*;
 
 /**
  * Consumer event class for some AI events
@@ -31,6 +33,7 @@ public class AiEvents {
     private final AiTranslationMapper aiTranslationMapper;
     private final RssTranslationService rssTranslationService;
     private final RssTranslationOrchestration rssTranslationOrchestration;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @EventListener
     public void onCreateRequestToTranslation(TranslationCreatedEvent translationCreatedEvent) {
@@ -39,9 +42,34 @@ public class AiEvents {
                     translationCreatedEvent.getStatusEnum());
 
             AiCleaningRequest cleaningRequests = aiTranslationMapper.convert(translationCreatedEvent.getRecords());
-            rssTranslationOrchestration.cleanInputText(cleaningRequests);
+            applicationEventPublisher.publishEvent(new RelevanceCheckCreatedEvent(cleaningRequests));
+            rssTranslationOrchestration.checkRelevance(cleaningRequests);
         } else {
             log.warn("For 'onCreateRequestToTranslation' produced empty data");
+        }
+    }
+
+    @EventListener
+    public void onRelevanceCheckCreated(RelevanceCheckCreatedEvent event) {
+        if (event != null) {
+            List<Long> idList = List.of(event.getAiCleaningRequest().getId());
+            rssTranslationService.queryUpdateStatusByListData(idList, RELEVANCE_CHECK_PROCESSING);
+        } else {
+            log.warn("For 'onRelevanceCheckCreated' produced empty data");
+        }
+    }
+
+    @EventListener
+    public void onRelevanceCheckCompleted(RelevanceCheckCompletedEvent event) {
+        if (event != null) {
+            if (event.isPassed()) {
+                rssTranslationOrchestration.cleanInputText(event.getAiCleaningRequest());
+            } else {
+                List<Long> idList = List.of(event.getAiCleaningRequest().getId());
+                rssTranslationService.queryUpdateStatusByListData(idList, SKIPPED, event.getReason());
+            }
+        } else {
+            log.warn("For 'onRelevanceCheckCompleted' produced empty data");
         }
     }
 

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/cleaning/AiCleaningRequest.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/cleaning/AiCleaningRequest.java
@@ -3,8 +3,6 @@ package com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning;
 import com.huawei.ai_platform.rss.infrastructure.persistence.entity.RssAttributeValue;
 import lombok.*;
 
-import java.util.List;
-
 /**
  * Cleaning request for the AI
  *
@@ -21,5 +19,6 @@ public class AiCleaningRequest {
     private String articleTitle;
     private String articleContent;
     private String articleLink;
+    private String categoryName;
     private RssAttributeValue attributes;
 }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/cleaning/RelevanceCheckRequest.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/cleaning/RelevanceCheckRequest.java
@@ -1,0 +1,21 @@
+package com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning;
+
+import lombok.*;
+
+/**
+ * Request for relevance check containing only necessary fields
+ *
+ * @author Borodulin Artem
+ * @since 2026.04.22
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RelevanceCheckRequest {
+    private long id;
+    private String title;
+    private String content;
+    private String categoryName;
+}

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/event/RelevanceCheckCompletedEvent.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/event/RelevanceCheckCompletedEvent.java
@@ -1,0 +1,21 @@
+package com.huawei.ai_platform.rss.infrastructure.ai.model.event;
+
+import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.AiCleaningRequest;
+import lombok.*;
+
+/**
+ * Wrapper class for relevance check completed event
+ *
+ * @author Borodulin Artem
+ * @since 2026.04.22
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RelevanceCheckCompletedEvent {
+    private AiCleaningRequest aiCleaningRequest;
+    private boolean passed;
+    private String reason;
+}

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/event/RelevanceCheckCreatedEvent.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/model/event/RelevanceCheckCreatedEvent.java
@@ -1,0 +1,19 @@
+package com.huawei.ai_platform.rss.infrastructure.ai.model.event;
+
+import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.AiCleaningRequest;
+import lombok.*;
+
+/**
+ * Wrapper class for relevance check start event
+ *
+ * @author Borodulin Artem
+ * @since 2026.04.22
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RelevanceCheckCreatedEvent {
+    private AiCleaningRequest aiCleaningRequest;
+}

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/executor/RelevanceStageExecutor.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/executor/RelevanceStageExecutor.java
@@ -1,0 +1,90 @@
+package com.huawei.ai_platform.rss.infrastructure.ai.pipeline.executor;
+
+import com.huawei.ai_platform.rss.infrastructure.ai.driver.AiExecutor;
+import com.huawei.ai_platform.rss.infrastructure.ai.exceptions.AiNullResultException;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.driver.IAiStageExecutor;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.stage.AIStageResponse;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.stage.AiStageParameters;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RelevanceStageExecutor implements IAiStageExecutor {
+    private final AiExecutor aiExecutor;
+
+    @Value("${ai.relevance.relevance-threshold:4}")
+    private int threshold;
+
+    @Override
+    public AIStageResponse runStage(@Nonnull AiStageParameters parameters) {
+        int countAttempts = 1;
+
+        ClassPathResource systemPromptResource = new ClassPathResource(parameters.getSystemPrompt());
+        ClassPathResource userPromptResource = new ClassPathResource(parameters.getUserPrompt());
+
+        while (countAttempts <= parameters.getMaxAttempts()) {
+            try (InputStream systemInputStream = systemPromptResource.getInputStream();
+                 InputStream userInputStream = userPromptResource.getInputStream()) {
+
+                String systemPromptContent = new String(systemInputStream.readAllBytes(), StandardCharsets.UTF_8);
+                String userPromptContent = String.format(new String(userInputStream.readAllBytes(), StandardCharsets.UTF_8),
+                        parameters.getUserPayload()
+                );
+
+                String result = aiExecutor.performOperation(systemPromptContent, userPromptContent, parameters.getTemperature());
+                if (result == null) {
+                    throw new AiNullResultException("Result from the AI is null");
+                }
+
+                int score = parseScore(result.trim());
+
+                if (score == -1) {
+                    log.warn("Invalid score on attempt {}/{}: {}", countAttempts, parameters.getMaxAttempts(), result);
+                    countAttempts++;
+                    continue;
+                }
+
+                if (score <= threshold) {
+                    log.info("Relevance check failed for ID={} (score={})", parameters.getId(), score);
+                    return AIStageResponse.failure("score=" + score + ", threshold=" + threshold);
+                }
+
+                log.info("Relevance check passed for ID={} (score={})", parameters.getId(), score);
+                return AIStageResponse.success(result);
+            } catch (Exception e) {
+                log.warn("Relevance check attempt {}/{} failed for ID={}: {}", countAttempts++, parameters.getMaxAttempts(), parameters.getId(), e.getMessage());
+            }
+        }
+
+        log.warn("Relevance check failed after {} attempts for ID={}, defaulting to pass", parameters.getMaxAttempts(), parameters.getId());
+        return AIStageResponse.failure("failed after " + parameters.getMaxAttempts() + " attempts");
+    }
+
+    private int parseScore(String response) {
+        String cleaned = response.trim();
+        String numberOnly = cleaned.replaceAll("[^0-9]", "");
+
+        if (numberOnly.isEmpty()) {
+            return -1;
+        }
+
+        try {
+            int score = Integer.parseInt(numberOnly);
+            if (score < 1 || score > 10) {
+                return -1;
+            }
+            return score;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/model/AIPipelineResponse.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/model/AIPipelineResponse.java
@@ -22,7 +22,7 @@ public class AIPipelineResponse {
     private String failureReason;
 
     public static AIPipelineResponse success(String pipelineName, String payload) {
-        return new AIPipelineResponse(true, pipelineName,  payload,"");
+        return new AIPipelineResponse(true, pipelineName, payload, "");
     }
 
     public static AIPipelineResponse failure(String pipelineName, String reason) {

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/model/stage/AIStageResponse.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/pipeline/model/stage/AIStageResponse.java
@@ -17,7 +17,7 @@ public class AIStageResponse {
     private String failureReason;
 
     public static AIStageResponse success(String payload) {
-        return new AIStageResponse(true,  payload,"");
+        return new AIStageResponse(true, payload, "");
     }
 
     public static AIStageResponse failure(String reason) {

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiRelevanceCheckRepo.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiRelevanceCheckRepo.java
@@ -1,0 +1,59 @@
+package com.huawei.ai_platform.rss.infrastructure.ai.repo;
+
+import com.huawei.ai_platform.rss.infrastructure.ai.model.cleaning.RelevanceCheckRequest;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.driver.AiPipelineExecutor;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.driver.IAiStageExecutor;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AIPipelineResponse;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AiPipelineBuilder;
+import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AiPipelineRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+
+/**
+ * Relevance check section for the AI
+ *
+ * @author Borodulin Artem
+ * @since 2026.04.22
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AiRelevanceCheckRepo {
+    public static final String PIPELINE_NAME = "RELEVANCE_CHECK";
+
+    private final IAiStageExecutor relevanceStageExecutor;
+    private final AiPipelineExecutor aiPipelineExecutor;
+
+    @Value("${ai.relevance.countAttempts}")
+    private int maxCountAttempts;
+
+    @Value("${ai.relevance.temperature}")
+    private Double temperature;
+
+    public RelevanceCheckResult checkRelevance(RelevanceCheckRequest request) {
+        String relevancePrompt = "prompt/relevance/relevance-check-prompt.txt";
+        String userPrompt = "prompt/user-prompt.txt";
+
+        String payload = String.format("Category: %s\nTitle: %s\nContent: %s",
+                request.getCategoryName() != null ? request.getCategoryName() : "",
+                request.getTitle() != null ? request.getTitle() : "",
+                request.getContent() != null ? request.getContent() : "");
+
+        AiPipelineRequest pipelineRequest = AiPipelineBuilder.createBuilder(PIPELINE_NAME)
+                .addStage(
+                        request.getId(), "RELEVANCE CHECK", relevanceStageExecutor,
+                        relevancePrompt, userPrompt, payload,
+                        "", temperature, maxCountAttempts
+                ).build();
+
+        AIPipelineResponse pipelineResponse = aiPipelineExecutor.executePipeline(pipelineRequest);
+        int score = Integer.parseInt(pipelineResponse.getPayload().trim());
+        return new RelevanceCheckResult(pipelineResponse.isSuccess(), score, pipelineResponse.getPayload());
+    }
+
+    public record RelevanceCheckResult(boolean passed, int score, String reason) {}
+}

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiTopArticlesOrchestrator.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiTopArticlesOrchestrator.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 @Component
 @Slf4j
 public class AiTopArticlesOrchestrator {
-
     private static final int MAX_ATTEMPTS = 5;
     private static final int TOP_ARTICLES_COUNT = 10;
 
@@ -319,24 +318,12 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
     }
     
     private Integer selectMostRelevant(List<ArticleData> articles, String categoryName, int categoryId, String runTimestamp) {
-        StringBuilder articlesList = new StringBuilder();
-        
-        for (int i = 0; i < articles.size(); i++) {
-            ArticleData a = articles.get(i);
-            String abstractText = a.content();
-            if (abstractText != null && abstractText.length() > 300) {
-                abstractText = abstractText.substring(0, 300) + "...";
-            }
-            articlesList.append(String.format("%d. %s\n   %s\n", 
-                i + 1, 
-                a.title() != null ? a.title() : "No title",
-                abstractText != null ? abstractText : "No abstract"));
-        }
-        
+        String articlesList = toString(articles);
+
         String promptTemplate = loadResource("/prompt/digest/selection-prompt.txt");
         String prompt = promptTemplate
             .replace("{{categoryName}}", categoryName)
-            .replace("{{articlesList}}", articlesList.toString());
+            .replace("{{articlesList}}", articlesList);
         
         try {
             String response = CompletableFuture.supplyAsync(() ->
@@ -365,6 +352,23 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
             log.error("Failed to select article: {}", e.getMessage());
             return null;
         }
+    }
+
+    private static String toString(List<ArticleData> articles) {
+        StringBuilder articlesList = new StringBuilder();
+
+        for (int i = 0; i < articles.size(); i++) {
+            ArticleData a = articles.get(i);
+            String abstractText = a.content();
+            if (abstractText != null && abstractText.length() > 300) {
+                abstractText = abstractText.substring(0, 300) + "...";
+            }
+            articlesList.append(String.format("%d. %s\n   %s\n",
+                i + 1,
+                a.title() != null ? a.title() : "No title",
+                abstractText != null ? abstractText : "No abstract"));
+        }
+        return articlesList.toString();
     }
 
     private <T> List<List<T>> splitIntoBatches(List<T> list, int size) {
@@ -461,21 +465,21 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
     
     private RssArticleSummaryCloud buildFullSummary(ArticleData article, ArticleSummary summaryEn) {
         try (ExecutorService executor = Executors.newFixedThreadPool(translationThreadPoolSize)) {
-            CompletableFuture<String> titleZh = CompletableFuture.supplyAsync(() -> translate(article.title()), executor);
-            CompletableFuture<String> abstractZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.articleAbstract()), executor);
             CompletableFuture<String> backgroundZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.background()), executor);
             CompletableFuture<String> eventSummaryZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.eventSummary()), executor);
             CompletableFuture<String> techZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.technologyAndInnovation()), executor);
             CompletableFuture<String> valueZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.valueAndImpact()), executor);
             CompletableFuture<String> effectsZh = CompletableFuture.supplyAsync(() -> translate(summaryEn.effects()), executor);
             
-            CompletableFuture.allOf(titleZh, abstractZh, backgroundZh, eventSummaryZh, techZh, valueZh, effectsZh).join();
+            CompletableFuture.allOf(backgroundZh, eventSummaryZh, techZh, valueZh, effectsZh).get(
+                translationTimeoutMs, TimeUnit.MILLISECONDS
+            );
             
             return RssArticleSummaryCloud.builder()
                 .articleTitleEn(article.title())
-                .articleTitleZh(titleZh.get())
-                .articleAbstractEn(summaryEn.articleAbstract())
-                .articleAbstractZh(abstractZh.get())
+                .articleTitleZh(article.titleZh())
+                .articleAbstractEn(article.content())
+                .articleAbstractZh(article.contentZh())
                 .backgroundEn(summaryEn.background())
                 .backgroundZh(backgroundZh.get())
                 .eventSummaryEn(summaryEn.eventSummary())
@@ -493,9 +497,9 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
             log.warn("Translation failed: {}", e.getMessage());
             return RssArticleSummaryCloud.builder()
                 .articleTitleEn(article.title())
-                .articleTitleZh(translate(article.title()))
-                .articleAbstractEn(summaryEn.articleAbstract())
-                .articleAbstractZh(translate(summaryEn.articleAbstract()))
+                .articleTitleZh(article.titleZh())
+                .articleAbstractEn(article.content())
+                .articleAbstractZh(article.contentZh())
                 .backgroundEn(summaryEn.background())
                 .backgroundZh(translate(summaryEn.background()))
                 .eventSummaryEn(summaryEn.eventSummary())
@@ -532,7 +536,6 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
                     .content();
                 
                 return response.trim();
-                
             } catch (Exception e) {
                 log.warn("Translation attempt {}/{} failed: {}", attempt, MAX_ATTEMPTS, e.getMessage());
             }
@@ -540,8 +543,6 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
         
         return text;
     }
-    
-    private record TranslationResult(String translation) {}
     
     private String generateCategorySummary(List<String> articleAbstracts, String categoryName) {
         if (articleAbstracts.isEmpty()) {
@@ -573,7 +574,6 @@ private List<ArticleScore> rankBatch(int categoryId, String categoryName,
 
     private String loadResource(String location) {
         try {
-            // ClassPathResource resource = new ClassPathResource(location);
             try (InputStream is = this.getClass().getResourceAsStream(location)) {
                 return new String(is.readAllBytes(), StandardCharsets.UTF_8);
             }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiTranslatorRepo.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/ai/repo/AiTranslatorRepo.java
@@ -8,11 +8,14 @@ import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AIPipelineRes
 import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AiPipelineBuilder;
 import com.huawei.ai_platform.rss.infrastructure.ai.pipeline.model.AiPipelineRequest;
 import jakarta.annotation.Nonnull;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import lombok.Singular;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -25,7 +28,13 @@ import java.util.Locale;
 @RequiredArgsConstructor
 @Slf4j
 public class AiTranslatorRepo {
-    public static final String PIPELINE_NAME = "CLEANING";
+    public static final String PIPELINE_NAME = "TRANSLATION";
+    private static final String TRANSLATING_PROMPT_EN = "prompt/translations/translation-prompt-en.txt";
+    private static final String TRANSLATING_PROMPT_ZH = "prompt/translations/translation-prompt-zh.txt";
+    private static final String NORMALIZATION_PROMPT_EN = "prompt/translations/normalization-prompt-en.txt";
+    private static final String NORMALIZATION_PROMPT_ZH = "prompt/translations/normalization-prompt-zh.txt";
+    private static final String FORMATTING_PROMPT = "prompt/translations/formatting-prompt.txt";
+    private static final String USER_PROMPT = "prompt/user-prompt.txt";
 
     private final IAiStageExecutor defaultAiExecutor;
     private final AiPipelineExecutor aiPipelineExecutor;
@@ -43,42 +52,76 @@ public class AiTranslatorRepo {
      * @return response data
      */
     public AiTranslationResponse translate(@Nonnull AiTranslationRequest request) {
-        AIPipelineResponse titleEn = exec(request, request.getArticleTitle(), Locale.ENGLISH);
-        AIPipelineResponse titleZh = exec(request, request.getArticleTitle(), Locale.SIMPLIFIED_CHINESE);
-        AIPipelineResponse contentEn = exec(request, request.getArticleContent(), Locale.ENGLISH);
-        AIPipelineResponse contentZh = exec(request, request.getArticleContent(), Locale.SIMPLIFIED_CHINESE);
+        TranslationConfig titleConfig = TranslationConfig.builder()
+            .request(request).payload(request.getArticleTitle()).locale(Locale.ENGLISH)
+            .stage(Stage.TRANSLATING).stage(Stage.NORMALIZATION)
+            .build();
+
+        TranslationConfig titleZhConfig = TranslationConfig.builder()
+            .request(request).payload(request.getArticleTitle()).locale(Locale.SIMPLIFIED_CHINESE)
+            .stage(Stage.TRANSLATING).stage(Stage.NORMALIZATION)
+            .build();
+
+        TranslationConfig contentConfig = TranslationConfig.builder()
+            .request(request).payload(request.getArticleContent()).locale(Locale.ENGLISH)
+            .stage(Stage.TRANSLATING).stage(Stage.NORMALIZATION).stage(Stage.FORMATTING)
+            .build();
+
+        TranslationConfig contentZhConfig = TranslationConfig.builder()
+            .request(request).payload(request.getArticleContent()).locale(Locale.SIMPLIFIED_CHINESE)
+            .stage(Stage.TRANSLATING).stage(Stage.NORMALIZATION).stage(Stage.FORMATTING)
+            .build();
+
+        AIPipelineResponse titleEn = exec(titleConfig);
+        AIPipelineResponse titleZh = exec(titleZhConfig);
+        AIPipelineResponse contentEn = exec(contentConfig);
+        AIPipelineResponse contentZh = exec(contentZhConfig);
 
         if (!(titleEn.isSuccess() && titleZh.isSuccess() && contentEn.isSuccess() && contentZh.isSuccess())) {
             return AiTranslationResponse.failureResponse(request.getArticleId(), "Not translated :(");
         }
 
         return AiTranslationResponse.successResponse(request.getArticleId(),
-                titleEn.getPayload(), titleZh.getPayload(), contentEn.getPayload(), contentZh.getPayload()
+            titleEn.getPayload(), titleZh.getPayload(), contentEn.getPayload(), contentZh.getPayload()
         );
     }
 
     /**
      * Performs executing data in the pipeline side
      *
-     * @param request cleaning request
-     * @param payload payload
+     * @param config translation config with all parameters
      * @return response from the pipeline
      */
-    private AIPipelineResponse exec(AiTranslationRequest request, String payload, Locale locale) {
-        String translationPrompt = locale == Locale.ENGLISH ? "prompt/translations/translation-prompt-en.txt" : "prompt/translations/translation-prompt-zh.txt";
-        String normalizingPrompt = locale == Locale.ENGLISH ? "prompt/translations/normalization-prompt-en.txt" : "prompt/translations/normalization-prompt-zh.txt";
+    private AIPipelineResponse exec(TranslationConfig config) {
+        String translationPrompt = config.locale() == Locale.ENGLISH ? TRANSLATING_PROMPT_EN : TRANSLATING_PROMPT_ZH;
+        String normalizingPrompt = config.locale() == Locale.ENGLISH ? NORMALIZATION_PROMPT_EN : NORMALIZATION_PROMPT_ZH;
 
-        String userPrompt = "prompt/user-prompt.txt";
+        AiPipelineBuilder builder = AiPipelineBuilder.createBuilder(PIPELINE_NAME);
 
-        AiPipelineRequest pipelineRequest = AiPipelineBuilder.createBuilder(PIPELINE_NAME)
-                .addStage(
-                        request.getArticleId(), "TRANSLATING", defaultAiExecutor, translationPrompt, userPrompt, payload,
-                        "", temperature, maxCountAttempts
-                )
-                .addStage(
-                        request.getArticleId(), "NORMALIZATION STAGE", defaultAiExecutor, normalizingPrompt, userPrompt,
-                        "", temperature, maxCountAttempts
-                ).build();
+        for (Stage stage : config.stages()) {
+            switch (stage) {
+                case TRANSLATING:
+                    builder.addStage(
+                        config.request().getArticleId(), "TRANSLATING", defaultAiExecutor,
+                        translationPrompt, USER_PROMPT, config.payload(), "", temperature, maxCountAttempts
+                    );
+                    break;
+                case NORMALIZATION:
+                    builder.addStage(
+                        config.request().getArticleId(), "NORMALIZATION STAGE", defaultAiExecutor,
+                        normalizingPrompt, USER_PROMPT, "", temperature, maxCountAttempts
+                    );
+                    break;
+                case FORMATTING:
+                    builder.addStage(
+                        config.request().getArticleId(), "FORMATTING STAGE", defaultAiExecutor,
+                        FORMATTING_PROMPT, USER_PROMPT, "", temperature, maxCountAttempts
+                    );
+                    break;
+            }
+        }
+
+        AiPipelineRequest pipelineRequest = builder.build();
 
         AIPipelineResponse pipelineResponse = aiPipelineExecutor.executePipeline(pipelineRequest);
 
@@ -87,5 +130,13 @@ public class AiTranslatorRepo {
         }
 
         return AIPipelineResponse.success(PIPELINE_NAME, pipelineResponse.getPayload());
+    }
+
+    public enum Stage {
+        TRANSLATING, NORMALIZATION, FORMATTING
+    }
+
+    @Builder
+    private record TranslationConfig(AiTranslationRequest request, String payload, Locale locale, @Singular List<Stage> stages) {
     }
 }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/dao/RssDao.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/dao/RssDao.java
@@ -93,7 +93,8 @@ public interface RssDao extends BaseMapper<RssEntity> {
      * @param articleTranslationStatusEnum status information
      */
     void queryUpdateStatusByListData(@Param("data") List<Long> items,
-                                     @Param("status") ArticleTranslationStatusEnum articleTranslationStatusEnum);
+                                     @Param("status") ArticleTranslationStatusEnum articleTranslationStatusEnum,
+                                     @Param("reason") String reason);
 
     /**
      * Extracts articles by category and date range

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/enums/ArticleTranslationStatusEnum.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/enums/ArticleTranslationStatusEnum.java
@@ -8,10 +8,12 @@ package com.huawei.ai_platform.rss.infrastructure.persistence.enums;
  */
 public enum ArticleTranslationStatusEnum {
     INIT,
+    RELEVANCE_CHECK_PROCESSING,
     CLEANING_PROCESSING,
     TRANSLATING_PROCESSING,
     FINISH,
-    FAILURE;
+    FAILURE,
+    SKIPPED;
 
     /**
      * Boolean flag means: whether article translated or not
@@ -19,6 +21,6 @@ public enum ArticleTranslationStatusEnum {
      * @return true if yes, false otherwise
      */
     public boolean isTranslated() {
-        return this == FINISH || this == FAILURE;
+        return this == FINISH || this == FAILURE || this == SKIPPED;
     }
 }

--- a/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/repo/RssPersistenceRepo.java
+++ b/src/main/java/com/huawei/ai_platform/rss/infrastructure/persistence/repo/RssPersistenceRepo.java
@@ -159,7 +159,16 @@ public class RssPersistenceRepo {
     @Transactional
     public void queryUpdateStatusByListData(@Nonnull List<Long> idList, @Nonnull ArticleTranslationStatusEnum statusEnum) {
         if (!CollectionUtils.isEmpty(idList)) {
-            rssDao.queryUpdateStatusByListData(idList, statusEnum);
+            rssDao.queryUpdateStatusByListData(idList, statusEnum, null);
+        } else {
+            log.info("queryUpdateStatusByListData(): Nothing to update");
+        }
+    }
+
+    @Transactional
+    public void queryUpdateStatusByListData(@Nonnull List<Long> idList, @Nonnull ArticleTranslationStatusEnum statusEnum, String reason) {
+        if (!CollectionUtils.isEmpty(idList)) {
+            rssDao.queryUpdateStatusByListData(idList, statusEnum, reason);
         } else {
             log.info("queryUpdateStatusByListData(): Nothing to update");
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,11 @@ ai:
   cleaning:
     temperature: 0.1
     countAttempts: 10
+  relevance:
+    model: deepseek/deepseek-v3.2
+    temperature: 0.1
+    countAttempts: 10
+    relevance-threshold: 4
   digest:
     batch-size: 50
     log-dir: /usr1/logs/llm

--- a/src/main/resources/mapper/RssMapper.xml
+++ b/src/main/resources/mapper/RssMapper.xml
@@ -28,7 +28,9 @@
 
     <update id="queryUpdateStatusByListData">
         UPDATE article_translations SET status = #{status}
-
+        <if test="reason != null">
+            , reason = #{reason}
+        </if>
         <where>
             article_create_date in
                 <foreach collection="data" item="item" open="(" close=")" separator=",">
@@ -152,7 +154,7 @@
             aTranslations.title_zh as titleZh,
             aCategory.id as categoryId
         from admin_entry entry
-        left join article_translations aTranslations on aTranslations.article_create_date = entry.id
+        inner join article_translations aTranslations on aTranslations.article_create_date = entry.id and aTranslations.status = 'FINISH'
         left join admin_feed feed ON entry.id_feed = feed.id
         left join admin_category aCategory ON feed.category = aCategory.id
         where aCategory.id = #{categoryId}
@@ -169,6 +171,7 @@
     <select id="countArticlesByCategoryAndDate" resultType="int">
         select count(*)
         from admin_entry entry
+        inner join article_translations aTranslations on aTranslations.article_create_date = entry.id and aTranslations.status = 'FINISH'
         left join admin_feed feed ON entry.id_feed = feed.id
         left join admin_category aCategory ON feed.category = aCategory.id
         where aCategory.id = #{categoryId}

--- a/src/main/resources/prompt/digest/article-summary-prompt.txt
+++ b/src/main/resources/prompt/digest/article-summary-prompt.txt
@@ -5,7 +5,6 @@ Abstract: {{abstract}}
 Full content: {{scrapedContent}}
 
 Analyze this article and return a JSON object with these EXACT fields:
-- articleAbstract: Key developments and trends in this article (2-3 sentences)
 - background: What context or trends does this fit into? What's the bigger picture? (2-4 sentences)
 - eventSummary: The main breakthrough or development in one sentence max 25 words
 - technologyAndInnovation: What new technologies, methods, or innovations are introduced? (2-4 sentences)

--- a/src/main/resources/prompt/digest/category-summary-prompt.txt
+++ b/src/main/resources/prompt/digest/category-summary-prompt.txt
@@ -11,4 +11,4 @@ Write a 3-4 sentence summary focusing on:
 - What these developments mean for the future
 - Key themes connecting these articles
 
-Return ONLY the summary text in English, nothing else. No markdown, no code blocks.
+Return ONLY the summary text in English, nothing else. No Markdown, no code blocks.

--- a/src/main/resources/prompt/relevance/relevance-check-prompt.txt
+++ b/src/main/resources/prompt/relevance/relevance-check-prompt.txt
@@ -1,0 +1,61 @@
+You are an article relevance evaluator for a scientific news aggregator.
+
+Evaluate the article below for relevance to its category.
+
+Rate on scale 1-10:
+- 1-3: NOT RELEVANT (different topic, no category terminology)
+- 4-5: LOOSELY RELATED (mentions category tangentially)
+- 6-7: RELEVANT (moderately related, some category content)
+- 8-10: HIGHLY RELEVANT (core topic, rich in category terminology)
+
+MIXED TOPICS RULE (IMPORTANT)
+
+If an article covers multiple topics and one of them matches the category:
+- Do NOT penalize for covering other topics
+- Do NOT require the article to be ONLY about this category
+- A 50/50 split (e.g., half AI, half medicine) scores 6-7, not 4-5
+- Multi-topic articles with significant category content score HIGHER, not lower
+
+EXAMPLES
+
+Article: "Cooking tips for beginner chefs"
+Category: Physics
+Expected score: 1-2 (completely unrelated)
+
+Article: "Celebrity buys luxury mansion"
+Category: Computer Science
+Expected score: 2-3 (faintly related via technology mentions)
+
+Article: "NASA announces Mars mission with AI navigation"
+Category: Computer Science
+Expected score: 6-7 (mixed content, AI component)
+
+Article: "Tech company releases new smartphone"
+Category: Computer Science
+Expected score: 4-5 (tech product, business angle)
+
+Article: "Stock market reaches all-time high"
+Category: Computer Science
+Expected score: 2-3 (finance, not CS)
+
+Article: "DeepMind develops AlphaFold3 for protein prediction"
+Category: Computer Science
+Expected score: 8-9 (AI research, core CS topic)
+
+Article: "New cancer treatment uses machine learning"
+Category: Computer Science
+Expected score: 7-8 (ML is core technology)
+
+Article: "Research team uses quantum computing for optimization"
+Category: Computer Science
+Expected score: 6-7 (quantum straddles fields)
+
+Article: "Apple announces record quarterly earnings"
+Category: Computer Science
+Expected score: 4-5 (tech business, some CS relevance)
+
+Article: "OpenAI releases GPT-5 with breakthrough capabilities"
+Category: Computer Science
+Expected score: 9-10 (cutting-edge AI, rich CS content)
+
+Respond with ONLY a single digit (1-10). No text.

--- a/src/main/resources/prompt/translations/formatting-prompt.txt
+++ b/src/main/resources/prompt/translations/formatting-prompt.txt
@@ -1,0 +1,146 @@
+You are a deterministic HTML formatter with ONE valid output: the final formatted article.
+
+EXECUTION MODEL (MANDATORY)
+
+You MUST follow this exact pipeline:
+
+- Extract content between ---BEGIN TEXT--- and ---END TEXT---
+- If no content exists → output: "NO_CONTENT"
+- Apply consistent formatting rules below
+- Output the result
+
+OUTPUT CHANNEL RULE (CRITICAL)
+
+You have EXACTLY ONE output channel: FINAL HTML.
+
+You MUST output ONLY the formatted HTML.
+No Markdown. No explanation. No comments.
+
+FORBIDDEN in output:
+
+- reasoning
+- thoughts
+- explanations
+- Markdown
+- JSON
+- CSS classes or inline styles
+- prefixes or suffixes
+- raw text without HTML tags
+
+SEMANTIC STRUCTURE (STRICT)
+
+Use this HTML hierarchy - choose appropriate tags based on content type:
+
+TITLES:
+- <h1> main title (one per article, first element after extraction)
+- <h2> major sections (only if article has clear distinct parts)
+- <h3> subsections (only within an <h2>)
+- <h4> details (only within an <h3>)
+
+TEXT:
+- <p> standard paragraphs
+- <span> inline text with semantic meaning
+- <strong> important terms (key information)
+- <em> emphasis (subtle stress)
+- <mark> highlighted/search-relevant text
+- <small> secondary information, fine print
+- <abbr> abbreviations (use title attribute)
+- <sub> subscript (chemical formulas, etc.)
+- <sup> superscript (powers, footnotes, etc.)
+
+QUOTES & CALLS:
+- <blockquote> quotations, callouts, notable quotes
+- <figure> standalone content (images with captions, quotes)
+- <figcaption> caption text within <figure>
+- <cite> source attribution
+
+LISTS:
+- <ul> unordered lists (bullets)
+- <ol> ordered lists (numbered steps)
+- <li> list items (never use bare text as list items)
+- <dl> definition lists (terms with definitions)
+- <dt> definition term
+- <dd> definition description
+
+TABLES (for tabular data):
+- <table> table container
+- <thead> header row group
+- <tbody> body row group
+- <tr> table row
+- <th> header cell (scope attribute for accessibility)
+- <td> data cell
+
+CODE & TECHNICAL:
+- <pre> code block container
+- <code> inline code
+- <kbd> keyboard input
+- <samp> sample output
+- <var> variable names
+
+MEDIA:
+- <img> images (preserve src, add alt text)
+- <figure> image with caption
+- <figcaption> image caption
+
+SEMANTIC SECTIONS:
+- <article> self-contained article content
+- <section> thematic grouping (use only within article)
+- <aside> tangential information
+- <details> collapsible disclosure (use with <summary>)
+- <summary> disclosure heading
+
+OTHER:
+- <hr> thematic break between major sections
+- <br> intentional line break within paragraph
+- <a> links (meaningful link text, not raw URLs)
+- <time> dates/time (use datetime attribute)
+
+STRUCTURE RULES
+
+For article structure:
+1. <h1> is the first element, one per article
+2. Use <section> only for major thematic groupings
+3. Every <section> should have a heading
+4. Never skip heading levels (h1 → h2 → h3 → h4)
+5. Lists must contain only <li> elements
+6. Tables need both <thead> and <tbody>
+7. Use <figure> for images with captions
+
+CONTENT RULES
+
+- Blank line between all block-level elements
+- Convert logical paragraphs to <p>
+- Use <br> only for intentional line breaks (poetry, address)
+- Preserve <img> tags exactly as provided
+- Use <strong> on key terms (once, not repeated)
+- Use <em> for subtle emphasis
+- Links must have descriptive text, not "click here"
+
+CONSISTENCY RULES
+
+For beautiful, consistent output:
+- Use semantic HTML5 tags only
+- No inline styles or class attributes
+- Proper nest hierarchy (ul > li, table > thead/tbody > tr > th/td)
+- All images should have alt text (copy from src if none)
+- Abbreviations need title attribute for full text
+- Dates in <time> with machine-readable datetime attribute
+- <figure> for any image with caption
+- Blockquotes for quotes over 40 words
+- <details>/<summary> for optional expanded information
+
+VALIDATION BEFORE OUTPUT
+
+Ensure ALL conditions are met:
+- Output is NOT empty (else return "NO_CONTENT")
+- Output contains only valid HTML tags and text
+- No Markdown formatting appears
+- All tags are properly closed
+- Heading hierarchy is maintained (no level skips)
+- Required child elements present (thead needs th, ul/ol needs li, etc.)
+
+FINAL INSTRUCTION
+
+Format article → output ONLY final semantic HTML.
+
+No reasoning. No explanations. No deviations.


### PR DESCRIPTION
- Add relevance check stage before cleaning/translation
- Articles with relevance score <= 4 are marked as SKIPPED
- Relevance check uses separate AI pipeline with flat text payload
- Add RELEVANCE_CHECK_PROCESSING status for progress tracking
- Filter SKIPPED articles from top articles and cloud upload
- Save relevance check reason to DB on SKIP
- Simplified: payload carries raw result, parse with Integer.parseInt()